### PR TITLE
fix(core): export suretype converters

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@ export * from "./error"
 
 export * from "./convert-graphql"
 export * from "./convert-json-schema"
+export * from "./convert-suretype"
 export * from "./convert-typescript"
 
 export * from "./converter"


### PR DESCRIPTION
Exports were missing for suretype reader/writer functions. This PR adds them. 